### PR TITLE
Optional dependency improvements

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -71,6 +71,11 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
                 }
                 level += 1
             }
+            
+            if property.isOptional {
+                return ProcessedProperty(unprocessed: property, sourceComponentType: nil)
+            }
+            
             var possibleMatches = [String]()
             var possibleMatchComponent: String?
             // Second pass, this time only match types to produce helpful warnings

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -65,7 +65,7 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
             // Level start at 1, since we dropped the current scope.
             var level = 1
             for component in searchPath {
-                if component.properties.contains(property) {
+                if component.properties.contains(property.removingOptionality) {
                     levelMap[component.name] = level
                     return ProcessedProperty(unprocessed: property, sourceComponentType: component.name)
                 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -113,6 +113,11 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
                 }
                 level += 1
             }
+            
+            if property.isOptional {
+                return PluginizedProcessedProperty(data: ProcessedProperty(unprocessed: property, sourceComponentType: nil), auxillarySourceType: nil, auxillarySourceName: nil)
+            }
+            
             var possibleMatches = [String]()
             var possibleMatchComponent: String?
             // Second pass, this time only match types to produce helpful warnings

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -100,7 +100,7 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
             // Level start at 1, since we dropped the current scope.
             var level = 1
             for component in searchPath {
-                if component.properties.contains(property) {
+                if component.properties.contains(property.removingOptionality) {
                     levelMap[component.name] = level
                     return PluginizedProcessedProperty(data: ProcessedProperty(unprocessed: property, sourceComponentType: component.name), auxillarySourceType: nil, auxillarySourceName: nil)
                 } else if let auxillaryProperties = auxillaryPropertyMap[component.name] {

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginizedPropertiesSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginizedPropertiesSerializer.swift
@@ -59,11 +59,19 @@ class PluginizedPropertiesSerializer: Serializer {
                 return ""
             }
         }()
-
-        return """
-            var \(property.data.unprocessed.name): \(property.data.unprocessed.type) {
-                return \(auxillaryPrefix)\(property.data.sourceComponentType.lowercasedFirstChar())\(auxillaryAccessor)\(auxillarySuffix).\(property.data.unprocessed.name)
-            }
-        """
+        
+        if let sourceComponentType = property.data.sourceComponentType {
+            return """
+                var \(property.data.unprocessed.name): \(property.data.unprocessed.type) {
+                    return \(auxillaryPrefix)\(sourceComponentType.lowercasedFirstChar())\(auxillaryAccessor)\(auxillarySuffix).\(property.data.unprocessed.name)
+                }
+            """
+        } else {
+            return """
+                var \(property.data.unprocessed.name): \(property.data.unprocessed.type) {
+                    return nil
+                }
+            """
+        }
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/PropertiesSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/PropertiesSerializer.swift
@@ -44,10 +44,18 @@ class PropertiesSerializer: Serializer {
     private let processedProperties: [ProcessedProperty]
 
     private func serialize(_ property: ProcessedProperty) -> String {
-        return """
-            var \(property.unprocessed.name): \(property.unprocessed.type) {
-                return \(property.sourceComponentType.lowercasedFirstChar()).\(property.unprocessed.name)
-            }
-        """
+        if let sourceComponentType = property.sourceComponentType {
+            return """
+                var \(property.unprocessed.name): \(property.unprocessed.type) {
+                    return \(sourceComponentType.lowercasedFirstChar()).\(property.unprocessed.name)
+                }
+            """
+        } else {
+            return """
+                var \(property.unprocessed.name): \(property.unprocessed.type) {
+                    return nil
+                }
+            """
+        }
     }
 }

--- a/Generator/Sources/NeedleFramework/Models/Property.swift
+++ b/Generator/Sources/NeedleFramework/Models/Property.swift
@@ -25,6 +25,20 @@ struct Property: Hashable {
     let type: String
     /// If this property is internal
     let isInternal: Bool
+    /// If this property is optional
+    var isOptional: Bool {
+        return type.hasSuffix("?")
+    }
+    /// A new property instance that removes 1 layer of optionality from the type if it is optional
+    var removingOptionality: Property {
+        if isOptional {
+            var type = type
+            type.removeLast()
+            return Property(name: name, type: type, isInternal: isInternal)
+        } else {
+            return self
+        }
+    }
     
     init(name: String, type: String, isInternal: Bool = false) {
         self.name = name

--- a/Generator/Sources/NeedleFramework/Models/Property.swift
+++ b/Generator/Sources/NeedleFramework/Models/Property.swift
@@ -57,5 +57,5 @@ struct ProcessedProperty: Equatable, Hashable {
     /// The unprocessed property we started with.
     let unprocessed: Property
     /// Type of the Component where this property is satisfied.
-    let sourceComponentType: String
+    let sourceComponentType: String?
 }


### PR DESCRIPTION
This updates the generator to detect optional dependencies and satisfy them with a matching non-optional version from among the component's ancestors. It will also no longer throw an error when an optional dependency is not provided by an an ancestor, defaulting the value to nil if no provider is found.

This allows for something like this: 

```Swift
final class LoggedOutComponent: BootstrapComponent {
    
    func loggedInComponent(userName: String) -> LoggedInComponent {
        return LoggedInComponent(userName: userName, parent: self)
    }
    
    var gameComponent: GameComponent {
        return GameComponent(parent: self)
    }
    
}

final class LoggedInComponent: Component<EmptyDependency> {
    
    let userName: String
    
    init(userName: String, parent: Scope) {
        self.userName = userName
        super.init(parent: parent)
    }
    
    var gameComponent: GameComponent {
        return GameComponent(parent: self)
    }
    
}

protocol GameDependency: Dependency {
    var userName: String? { get }
}

final class GameComponent: Component<GameDependency> {}
```
In this example, GameComponent has an optional dependency of userName that would be provided by LoggedInComponent when created from that scope, but would be nil when created from the LoggedOutComponent scope since there is no provider.